### PR TITLE
clear flags when relation is departed

### DIFF
--- a/src/ceph_client/requires.py
+++ b/src/ceph_client/requires.py
@@ -20,27 +20,22 @@ from charms.reactive import (
 
 
 class CephClientRequires(base_requires.CephRequires):
-
-    @when('endpoint.{endpoint_name}.joined')
+    @when("endpoint.{endpoint_name}.joined")
     def joined(self):
         super().joined()
 
-    @when('endpoint.{endpoint_name}.changed')
+    @when("endpoint.{endpoint_name}.changed")
     def changed(self):
         super().changed()
 
-    @when('endpoint.{endpoint_name}.departed')
+    @when("endpoint.{endpoint_name}.departed")
     def departed(self):
         super().changed()
 
-    @when('endpoint.{endpoint_name}.broken')
+    @when("endpoint.{endpoint_name}.broken")
     def broken(self):
         super().broken()
 
     def initial_ceph_response(self):
-        data = {
-            'key': self.key,
-            'auth': self.auth,
-            'mon_hosts': self.mon_hosts()
-        }
+        data = {"key": self.key, "auth": self.auth, "mon_hosts": self.mon_hosts()}
         return data

--- a/src/ceph_mds/requires.py
+++ b/src/ceph_mds/requires.py
@@ -26,21 +26,21 @@ from charmhelpers.contrib.storage.linux.ceph import (
 
 class CephClient(base_requires.CephRequires):
 
-    ceph_pool_app_name = 'cephfs'
+    ceph_pool_app_name = "cephfs"
 
-    @when('endpoint.{endpoint_name}.joined')
+    @when("endpoint.{endpoint_name}.joined")
     def joined(self):
         super().joined()
 
-    @when('endpoint.{endpoint_name}.changed')
+    @when("endpoint.{endpoint_name}.changed")
     def changed(self):
         super().changed()
 
-    @when('endpoint.{endpoint_name}.departed')
+    @when("endpoint.{endpoint_name}.departed")
     def departed(self):
         super().changed()
 
-    @when('endpoint.{endpoint_name}.broken')
+    @when("endpoint.{endpoint_name}.broken")
     def broken(self):
         super().broken()
 
@@ -49,25 +49,26 @@ class CephClient(base_requires.CephRequires):
         return self._fsid()
 
     def _fsid(self):
-        return self.all_joined_units.received.get('fsid')
+        return self.all_joined_units.received.get("fsid")
 
     def mds_key(self):
         """Retrieve the cephx key for the local mds unit"""
         return self.all_joined_units.received.get(
-            '{}_mds_key'.format(socket.gethostname()))
+            "{}_mds_key".format(socket.gethostname())
+        )
 
     def initial_ceph_response(self):
         data = {
-            'mds_key': self.mds_key(),
-            'fsid': self.fsid,
-            'auth': self.auth,
-            'mon_hosts': self.mon_hosts()
+            "mds_key": self.mds_key(),
+            "fsid": self.fsid,
+            "auth": self.auth,
+            "mon_hosts": self.mon_hosts(),
         }
         return data
 
     def announce_mds_name(self):
         for relation in self.relations:
-            relation.to_publish_raw['mds-name'] = socket.gethostname()
+            relation.to_publish_raw["mds-name"] = socket.gethostname()
 
     def request_cephfs(self, name, extra_pools=None):
         """Request creation of Ceph FS
@@ -78,12 +79,15 @@ class CephClient(base_requires.CephRequires):
         :type extra_pools: List[str]
         """
         rq = self.get_current_request() or CephBrokerRq()
-        rq.add_op({
-            'op': 'create-cephfs',
-            'mds_name': name,
-            'data_pool': "{}_data".format(name),
-            'extra_pools': extra_pools,
-            'metadata_pool': "{}_metadata".format(name)})
+        rq.add_op(
+            {
+                "op": "create-cephfs",
+                "mds_name": name,
+                "data_pool": "{}_data".format(name),
+                "extra_pools": extra_pools,
+                "metadata_pool": "{}_metadata".format(name),
+            }
+        )
         self.send_request_if_needed(rq)
 
     def initialize_mds(self, name, replicas=3):
@@ -97,10 +101,12 @@ class CephClient(base_requires.CephRequires):
             name="{}_data".format(name),
             replicas=replicas,
             weight=None,
-            app_name=self.ceph_pool_app_name)
+            app_name=self.ceph_pool_app_name,
+        )
         self.create_replicated_pool(
             name="{}_metadata".format(name),
             replicas=replicas,
             weight=None,
-            app_name=self.ceph_pool_app_name)
+            app_name=self.ceph_pool_app_name,
+        )
         self.request_cephfs(name)

--- a/src/lib/base_provides.py
+++ b/src/lib/base_provides.py
@@ -5,6 +5,7 @@ from charmhelpers.core.hookenv import (
 from charms.reactive import RelationBase
 from charms.reactive import hook
 from charms.reactive import scopes
+
 # from charms.reactive import is_state
 # from charms.reactive import not_unless
 
@@ -12,13 +13,13 @@ from charms.reactive import scopes
 class CephProvides(RelationBase):
     scope = scopes.UNIT
 
-    @hook('{provides:ceph-client}-relation-{joined,changed}')
+    @hook("{provides:ceph-client}-relation-{joined,changed}")
     def changed(self):
-        self.set_state('{relation_name}.connected')
+        self.set_state("{relation_name}.connected")
         # service = hookenv.remote_service_name()
         conversation = self.conversation()
-        if conversation.get_remote('broker_req'):
-            self.set_state('{relation_name}.broker_requested')
+        if conversation.get_remote("broker_req"):
+            self.set_state("{relation_name}.broker_requested")
 
     def provide_auth(self, service, key, auth_supported, public_address):
         """
@@ -32,12 +33,10 @@ class CephProvides(RelationBase):
         # print("Conversation is ", conversation)
         # key is a keyword argument to the set_remote function so we have to
         # set it separately.
-        relation_set(
-            relation_id=conversation.namespace,
-            relation_settings={'key': key})
+        relation_set(relation_id=conversation.namespace, relation_settings={"key": key})
         opts = {
-            'auth': auth_supported,
-            'ceph-public-address': public_address,
+            "auth": auth_supported,
+            "ceph-public-address": public_address,
         }
         conversation.set_remote(**opts)
 
@@ -59,7 +58,7 @@ class CephProvides(RelationBase):
         """
         Return the key provided to the requesting service.
         """
-        return self.conversation(scope=service).get_remote('key')
+        return self.conversation(scope=service).get_remote("key")
 
     def provide_broker_token(self, service, unit_response_key, token):
         """
@@ -72,10 +71,12 @@ class CephProvides(RelationBase):
 
         # broker_rsp is being left for backward compatibility,
         # unit_response_key superscedes it
-        conversation.set_remote(**{
-            'broker_rsp': token,
-            unit_response_key: token,
-        })
+        conversation.set_remote(
+            **{
+                "broker_rsp": token,
+                unit_response_key: token,
+            }
+        )
 
     def requested_tokens(self):
         """
@@ -94,4 +95,4 @@ class CephProvides(RelationBase):
         """
         Return the token provided to the requesting service.
         """
-        return self.conversation(scope=service).get_remote('broker_req')
+        return self.conversation(scope=service).get_remote("broker_req")

--- a/src/lib/base_requires.py
+++ b/src/lib/base_requires.py
@@ -31,27 +31,26 @@ from charmhelpers.contrib.storage.linux.ceph import (
 
 
 class CephRequires(reactive.Endpoint):
-
     def joined(self):
-        reactive.set_flag(self.expand_name('{endpoint_name}.connected'))
+        reactive.set_flag(self.expand_name("{endpoint_name}.connected"))
 
     @property
     def key(self):
         return self._key()
 
     def _key(self):
-        return self.all_joined_units.received.get('key')
+        return self.all_joined_units.received.get("key")
 
     @property
     def auth(self):
         return self._auth()
 
     def _auth(self):
-        return self.all_joined_units.received.get('auth')
+        return self.all_joined_units.received.get("auth")
 
     @property
     def relation_name(self):
-        return self.expand_name('{endpoint_name}')
+        return self.expand_name("{endpoint_name}")
 
     def initial_ceph_response(self):
         raise NotImplementedError
@@ -59,7 +58,7 @@ class CephRequires(reactive.Endpoint):
     def changed(self):
         data = self.initial_ceph_response()
         if all(data.values()):
-            reactive.set_flag(self.expand_name('{endpoint_name}.available'))
+            reactive.set_flag(self.expand_name("{endpoint_name}.available"))
 
         rq = self.get_current_request()
         if rq:
@@ -67,22 +66,26 @@ class CephRequires(reactive.Endpoint):
 
             if rq and is_request_complete(rq, relation=self.relation_name):
                 log("Setting ceph-client.pools.available")
-                reactive.set_flag(
-                    self.expand_name('{endpoint_name}.pools.available'))
+                reactive.set_flag(self.expand_name("{endpoint_name}.pools.available"))
             else:
                 log("incomplete request. broker_req not found")
 
     def broken(self):
-        reactive.clear_flag(
-            self.expand_name('{endpoint_name}.available'))
-        reactive.clear_flag(
-            self.expand_name('{endpoint_name}.connected'))
-        reactive.clear_flag(
-            self.expand_name('{endpoint_name}.pools.available'))
+        reactive.clear_flag(self.expand_name("{endpoint_name}.available"))
+        reactive.clear_flag(self.expand_name("{endpoint_name}.connected"))
+        reactive.clear_flag(self.expand_name("{endpoint_name}.pools.available"))
 
-    def create_replicated_pool(self, name, replicas=3, weight=None,
-                               pg_num=None, group=None, namespace=None,
-                               app_name=None, **kwargs):
+    def create_replicated_pool(
+        self,
+        name,
+        replicas=3,
+        weight=None,
+        pg_num=None,
+        group=None,
+        namespace=None,
+        app_name=None,
+        **kwargs
+    ):
         """
         Request pool setup
 
@@ -113,22 +116,24 @@ class CephRequires(reactive.Endpoint):
         :type kwargs: Dict[str,any]
         """
         rq = self.get_current_request() or CephBrokerRq()
-        kwargs.update({
-            'name': name,
-            'replica_count': replicas,
-            'pg_num': pg_num,
-            'weight': weight,
-            'group': group,
-            'namespace': namespace,
-            'app_name': app_name,
-        })
+        kwargs.update(
+            {
+                "name": name,
+                "replica_count": replicas,
+                "pg_num": pg_num,
+                "weight": weight,
+                "group": group,
+                "namespace": namespace,
+                "app_name": app_name,
+            }
+        )
         rq.add_op_create_replicated_pool(**kwargs)
         self.send_request_if_needed(rq)
-        reactive.clear_flag(
-            self.expand_name('{endpoint_name}.pools.available'))
+        reactive.clear_flag(self.expand_name("{endpoint_name}.pools.available"))
 
-    def create_pool(self, name, replicas=3, weight=None, pg_num=None,
-                    group=None, namespace=None):
+    def create_pool(
+        self, name, replicas=3, weight=None, pg_num=None, group=None, namespace=None
+    ):
         """
         Request pool setup -- deprecated. Please use create_replicated_pool
         or create_erasure_pool(which doesn't exist yet)
@@ -144,14 +149,20 @@ class CephRequires(reactive.Endpoint):
         @param namespace: A group can optionally have a namespace defined that
                           will be used to further restrict pool access.
         """
-        self.create_replicated_pool(name, replicas, weight, pg_num, group,
-                                    namespace)
+        self.create_replicated_pool(name, replicas, weight, pg_num, group, namespace)
 
-    def create_erasure_pool(self, name, erasure_profile=None,
-                            weight=None, group=None, app_name=None,
-                            max_bytes=None, max_objects=None,
-                            allow_ec_overwrites=False,
-                            **kwargs):
+    def create_erasure_pool(
+        self,
+        name,
+        erasure_profile=None,
+        weight=None,
+        group=None,
+        app_name=None,
+        max_bytes=None,
+        max_objects=None,
+        allow_ec_overwrites=False,
+        **kwargs
+    ):
         """
         Request erasure coded pool setup
 
@@ -177,32 +188,37 @@ class CephRequires(reactive.Endpoint):
         :type kwargs: Dict[str,any]
         """
         rq = self.get_current_request() or CephBrokerRq()
-        kwargs.update({
-            'name': name,
-            'erasure_profile': erasure_profile,
-            'weight': weight,
-            'group': group,
-            'app_name': app_name,
-            'max_bytes': max_bytes,
-            'max_objects': max_objects,
-            'allow_ec_overwrites': allow_ec_overwrites,
-        })
+        kwargs.update(
+            {
+                "name": name,
+                "erasure_profile": erasure_profile,
+                "weight": weight,
+                "group": group,
+                "app_name": app_name,
+                "max_bytes": max_bytes,
+                "max_objects": max_objects,
+                "allow_ec_overwrites": allow_ec_overwrites,
+            }
+        )
         rq.add_op_create_erasure_pool(**kwargs)
         self.send_request_if_needed(rq)
-        reactive.clear_flag(
-            self.expand_name('{endpoint_name}.pools.available'))
+        reactive.clear_flag(self.expand_name("{endpoint_name}.pools.available"))
 
-    def create_erasure_profile(self, name,
-                               erasure_type='jerasure',
-                               erasure_technique=None,
-                               k=None, m=None,
-                               failure_domain=None,
-                               lrc_locality=None,
-                               shec_durability_estimator=None,
-                               clay_helper_chunks=None,
-                               device_class=None,
-                               clay_scalar_mds=None,
-                               lrc_crush_locality=None):
+    def create_erasure_profile(
+        self,
+        name,
+        erasure_type="jerasure",
+        erasure_technique=None,
+        k=None,
+        m=None,
+        failure_domain=None,
+        lrc_locality=None,
+        shec_durability_estimator=None,
+        clay_helper_chunks=None,
+        device_class=None,
+        clay_scalar_mds=None,
+        lrc_crush_locality=None,
+    ):
         """
         Create erasure coding profile
 
@@ -235,22 +251,27 @@ class CephRequires(reactive.Endpoint):
             name=name,
             erasure_type=erasure_type,
             erasure_technique=erasure_technique,
-            k=k, m=m,
+            k=k,
+            m=m,
             failure_domain=failure_domain,
             lrc_locality=lrc_locality,
             shec_durability_estimator=shec_durability_estimator,
             clay_helper_chunks=clay_helper_chunks,
             device_class=device_class,
             clay_scalar_mds=clay_scalar_mds,
-            lrc_crush_locality=lrc_crush_locality
+            lrc_crush_locality=lrc_crush_locality,
         )
         self.send_request_if_needed(rq)
-        reactive.clear_flag(
-            self.expand_name('{endpoint_name}.pools.available'))
+        reactive.clear_flag(self.expand_name("{endpoint_name}.pools.available"))
 
-    def request_access_to_group(self, name, namespace=None, permission=None,
-                                key_name=None,
-                                object_prefix_permissions=None):
+    def request_access_to_group(
+        self,
+        name,
+        namespace=None,
+        permission=None,
+        key_name=None,
+        object_prefix_permissions=None,
+    ):
         """
         Adds the requested permissions to service's Ceph key
 
@@ -274,7 +295,8 @@ class CephRequires(reactive.Endpoint):
             namespace=namespace,
             permission=permission,
             key_name=key_name,
-            object_prefix_permissions=object_prefix_permissions)
+            object_prefix_permissions=object_prefix_permissions,
+        )
         self.send_request_if_needed(current_request)
 
     def send_request_if_needed(self, request):
@@ -283,23 +305,20 @@ class CephRequires(reactive.Endpoint):
         @param request: A CephBrokerRq object
         """
         if is_request_sent(request, relation=self.relation_name):
-            log('Request already sent but not complete, '
-                'not sending new request')
+            log("Request already sent but not complete, " "not sending new request")
         else:
             for relation in self.relations:
-                relation.to_publish['broker_req'] = json.loads(
-                    request.request)
-                relation.to_publish_raw[
-                    'application-name'] = application_name()
-                relation.to_publish_raw['unit-name'] = local_unit()
+                relation.to_publish["broker_req"] = json.loads(request.request)
+                relation.to_publish_raw["application-name"] = application_name()
+                relation.to_publish_raw["unit-name"] = local_unit()
 
     def get_current_request(self):
         broker_reqs = []
         for relation in self.relations:
-            broker_req = relation.to_publish.get('broker_req', {})
+            broker_req = relation.to_publish.get("broker_req", {})
             if broker_req:
                 rq = CephBrokerRq()
-                rq.set_ops(broker_req['ops'])
+                rq.set_ops(broker_req["ops"])
                 broker_reqs.append(rq)
         # Check that if there are multiple requests then they are the same.
         assert all(x == broker_reqs[0] for x in broker_reqs)
@@ -319,13 +338,13 @@ class CephRequires(reactive.Endpoint):
     def mon_hosts(self):
         """List of all monitor host public addresses"""
         hosts = []
-        addrs = self.get_remote_all('ceph-public-address')
+        addrs = self.get_remote_all("ceph-public-address")
         for ceph_addrs in addrs:
             # NOTE(jamespage): This looks odd but deals with
             #                  use with ceph-proxy which
             #                  presents all monitors in
             #                  a single space delimited field.
-            for addr in ceph_addrs.split(' '):
+            for addr in ceph_addrs.split(" "):
                 hosts.append(format_ipv6_addr(addr) or addr)
         hosts.sort()
         return hosts

--- a/src/lib/base_requires.py
+++ b/src/lib/base_requires.py
@@ -70,6 +70,16 @@ class CephRequires(reactive.Endpoint):
             else:
                 log("incomplete request. broker_req not found")
 
+    def manage_flags(self):
+        """
+        Set states corresponding to the data we have.
+        """
+        reactive.toggle_flag(
+            self.expand_name("{endpoint_name}.connected"), self.is_joined
+        )
+        if not self.is_joined:
+            self.broken()
+
     def broken(self):
         reactive.clear_flag(self.expand_name("{endpoint_name}.available"))
         reactive.clear_flag(self.expand_name("{endpoint_name}.connected"))

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,5 @@
 # Lint and unit test requirements
+black
 flake8
 stestr>=2.2.0
 charms.reactive

--- a/tox.ini
+++ b/tox.ini
@@ -41,7 +41,14 @@ commands = stestr run {posargs}
 [testenv:pep8]
 basepython = python3
 deps = -r{toxinidir}/test-requirements.txt
-commands = flake8 {posargs}
+commands = 
+  flake8 {posargs}
+  black --check {toxinidir}
+
+[testenv:format]
+envdir = {toxworkdir}/pep8
+deps = -r{toxinidir}/test-requirements.txt
+commands = black {toxinidir}
 
 [testenv:venv]
 basepython = python3
@@ -49,3 +56,5 @@ commands = {posargs}
 
 [flake8]
 ignore = E402,E226
+exclude=.tox
+max-line-length = 88

--- a/unit_tests/__init__.py
+++ b/unit_tests/__init__.py
@@ -14,4 +14,4 @@
 
 import sys
 
-sys.path.append('src')
+sys.path.append("src")

--- a/unit_tests/test_provides.py
+++ b/unit_tests/test_provides.py
@@ -15,33 +15,32 @@ import unittest
 from unittest import mock
 
 
-with mock.patch('charmhelpers.core.hookenv.metadata') as _meta:
-    _meta.return_Value = 'ss'
+with mock.patch("charmhelpers.core.hookenv.metadata") as _meta:
+    _meta.return_Value = "ss"
     from ceph_client import provides
 
 _hook_args = {}
 
 TO_PATCH = []
 TO_PATCH_BASE_PROVIDES = [
-    'relation_set',
+    "relation_set",
 ]
 
 
 def mock_hook(*args, **kwargs):
-
     def inner(f):
         # remember what we were passed.  Note that we can't actually determine
         # the class we're attached to, as the decorator only gets the function.
         _hook_args[f.__name__] = dict(args=args, kwargs=kwargs)
         return f
+
     return inner
 
 
 class TestCephClientProvider(unittest.TestCase):
-
     @classmethod
     def setUpClass(cls):
-        cls._patched_hook = mock.patch('charms.reactive.when', mock_hook)
+        cls._patched_hook = mock.patch("charms.reactive.when", mock_hook)
         cls._patched_hook_started = cls._patched_hook.start()
         # force requires to rerun the mock_hook decorator:
         # try except is Python2/Python3 compatibility as Python3 has moved
@@ -50,6 +49,7 @@ class TestCephClientProvider(unittest.TestCase):
             reload(provides)
         except NameError:
             import importlib
+
             importlib.reload(provides)
 
     @classmethod
@@ -62,6 +62,7 @@ class TestCephClientProvider(unittest.TestCase):
             reload(provides)
         except NameError:
             import importlib
+
             importlib.reload(provides)
 
     def patch(self, method, obj=None):
@@ -72,7 +73,7 @@ class TestCephClientProvider(unittest.TestCase):
         return _mock
 
     def setUp(self):
-        self.cr = provides.CephClientProvider('some-relation', [])
+        self.cr = provides.CephClientProvider("some-relation", [])
         self._patches = {}
         self._patches_start = {}
         self.obj = provides
@@ -103,98 +104,86 @@ class TestCephClientProvider(unittest.TestCase):
         # handle regressions.
         # The keys are the function names that the hook attaches to.
         hook_patterns = {
-            'data_changed': ('endpoint.{endpoint_name}.changed', ),
-            'joined': ('endpoint.{endpoint_name}.joined', ),
-            'broken': ('endpoint.{endpoint_name}.joined', ),
+            "data_changed": ("endpoint.{endpoint_name}.changed",),
+            "joined": ("endpoint.{endpoint_name}.joined",),
+            "broken": ("endpoint.{endpoint_name}.joined",),
         }
         for k, v in _hook_args.items():
-            self.assertEqual(hook_patterns[k], v['args'])
+            self.assertEqual(hook_patterns[k], v["args"])
 
     def test_changed(self):
         conv1 = mock.MagicMock()
         conv1.get_remote.return_value = True
-        self.patch_kr('conversation', conv1)
-        self.patch_kr('set_state')
+        self.patch_kr("conversation", conv1)
+        self.patch_kr("set_state")
         self.cr.changed()
-        self.set_state.assert_has_calls([
-            mock.call('{relation_name}.connected'),
-            mock.call('{relation_name}.broker_requested')])
+        self.set_state.assert_has_calls(
+            [
+                mock.call("{relation_name}.connected"),
+                mock.call("{relation_name}.broker_requested"),
+            ]
+        )
 
     def test_changed_no_request(self):
         conv1 = mock.MagicMock()
         conv1.get_remote.return_value = None
-        self.patch_kr('conversation', conv1)
-        self.patch_kr('set_state')
+        self.patch_kr("conversation", conv1)
+        self.patch_kr("set_state")
         self.cr.changed()
-        self.set_state.assert_called_once_with('{relation_name}.connected')
+        self.set_state.assert_called_once_with("{relation_name}.connected")
 
     def test_provide_auth(self):
         conv1 = mock.MagicMock()
         conv1.get_remote.return_value = None
-        conv1.namespace = 'ns1'
-        self.patch_kr('conversation', conv1)
-        self.cr.provide_auth(
-            'svc1',
-            'secret',
-            'ssl1.0',
-            '10.0.0.10')
-        expect = {
-            'auth': 'ssl1.0',
-            'ceph-public-address': '10.0.0.10'}
+        conv1.namespace = "ns1"
+        self.patch_kr("conversation", conv1)
+        self.cr.provide_auth("svc1", "secret", "ssl1.0", "10.0.0.10")
+        expect = {"auth": "ssl1.0", "ceph-public-address": "10.0.0.10"}
         conv1.set_remote.assert_called_once_with(**expect)
         self.relation_set.assert_called_once_with(
-            relation_id='ns1',
-            relation_settings={'key': 'secret'})
+            relation_id="ns1", relation_settings={"key": "secret"}
+        )
 
     def test_requested_keys(self):
         conv1 = mock.MagicMock()
-        conv1.scope = 'svc1'
+        conv1.scope = "svc1"
         conv2 = mock.MagicMock()
-        conv2.scope = 'svc2'
-        self.patch_kr('conversations', [conv1, conv2])
-        self.patch_kr('requested_key')
-        keys = {
-            'svc1': 'key'}
+        conv2.scope = "svc2"
+        self.patch_kr("conversations", [conv1, conv2])
+        self.patch_kr("requested_key")
+        keys = {"svc1": "key"}
         self.requested_key.side_effect = lambda x: keys.get(x)
-        self.assertEqual(
-            list(self.cr.requested_keys()),
-            ['svc2'])
+        self.assertEqual(list(self.cr.requested_keys()), ["svc2"])
 
     def test_requested_key(self):
         conv1 = mock.MagicMock()
-        self.patch_kr('conversation', conv1)
-        self.cr.requested_key('svc1')
-        self.conversation.assert_called_once_with(scope='svc1')
-        self.conversation(scope='svc1').get_remote.assert_called_once_with(
-            'key')
+        self.patch_kr("conversation", conv1)
+        self.cr.requested_key("svc1")
+        self.conversation.assert_called_once_with(scope="svc1")
+        self.conversation(scope="svc1").get_remote.assert_called_once_with("key")
 
     def test_provide_broker_token(self):
         conv1 = mock.MagicMock()
-        self.patch_kr('conversation', conv1)
-        self.cr.provide_broker_token('svc1', 'urkey', 'token1')
-        conv1.set_remote.assert_called_once_with(
-            broker_rsp='token1',
-            urkey='token1')
+        self.patch_kr("conversation", conv1)
+        self.cr.provide_broker_token("svc1", "urkey", "token1")
+        conv1.set_remote.assert_called_once_with(broker_rsp="token1", urkey="token1")
 
     def test_requested_tokens(self):
         conv1 = mock.MagicMock()
-        conv1.scope = 'svc1'
+        conv1.scope = "svc1"
         conv2 = mock.MagicMock()
-        conv2.scope = 'svc2'
-        self.patch_kr('conversations', [conv1, conv2])
-        tokens = {
-            'svc1': 'token1',
-            'svc2': 'token2'}
-        self.patch_kr('requested_token')
+        conv2.scope = "svc2"
+        self.patch_kr("conversations", [conv1, conv2])
+        tokens = {"svc1": "token1", "svc2": "token2"}
+        self.patch_kr("requested_token")
         self.requested_token.side_effect = lambda x: tokens.get(x)
         self.assertEqual(
-            list(self.cr.requested_tokens()),
-            [('svc1', 'token1'), ('svc2', 'token2')])
+            list(self.cr.requested_tokens()), [("svc1", "token1"), ("svc2", "token2")]
+        )
 
     def test_requested_token(self):
         conv1 = mock.MagicMock()
-        self.patch_kr('conversation', conv1)
-        self.cr.requested_token('svc1')
-        self.conversation.assert_called_once_with(scope='svc1')
-        self.conversation(scope='svc1').get_remote.assert_called_once_with(
-            'broker_req')
+        self.patch_kr("conversation", conv1)
+        self.cr.requested_token("svc1")
+        self.conversation.assert_called_once_with(scope="svc1")
+        self.conversation(scope="svc1").get_remote.assert_called_once_with("broker_req")

--- a/unit_tests/test_requires.py
+++ b/unit_tests/test_requires.py
@@ -183,6 +183,16 @@ class TestCephClientRequires(unittest.TestCase):
         # Side effect of asserting pools.available was not set.
         self.set_flag.assert_called_once_with("some-relation.available")
 
+    def test_manage_flags(self):
+        self.cr.manage_flags()
+        self.clear_flag.assert_has_calls(
+            [
+                mock.call("some-relation.available"),
+                mock.call("some-relation.connected"),
+                mock.call("some-relation.pools.available"),
+            ]
+        )
+
     def test_broken(self):
         self.cr.broken()
         self.clear_flag.assert_has_calls(


### PR DESCRIPTION
interesting changes are [here](https://github.com/openstack/charm-interface-ceph-client/compare/master...charmed-kubernetes:charm-interface-ceph-client:clear_flags_after_departed?expand=1#diff-9eb0cb7a15a52ca9e978e7150798993d49d90ac39883bb3e7bf50fd573384bb1R73-R86)

This PR would clean up if https://github.com/openstack/charm-interface-ceph-client/pull/2 was merged and rebased into this branch

This code addresses an issue where the ceph endpoint flags aren't cleaned up following the removal of ceph client relation from the kubernetes-control-plane charm.  See [charms.reactive](https://github.com/juju-solutions/charms.reactive/blob/master/charms/reactive/endpoints.py#L218-L251) for more details

